### PR TITLE
Organizers can sample/run lottery on waitlisted users

### DIFF
--- a/tigers-lottery/app/src/main/java/com/example/tigers_lottery/HostedEvents/OrganizerCreateEventFragment.java
+++ b/tigers-lottery/app/src/main/java/com/example/tigers_lottery/HostedEvents/OrganizerCreateEventFragment.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 
 public class OrganizerCreateEventFragment extends Fragment {
 
-    private EditText inputEventName, inputEventLocation, inputRegistrationOpens, inputRegistrationDeadline, inputEventDate, inputEventDescription, inputWaitlistLimit;
+    private EditText inputEventName, inputEventLocation, inputRegistrationOpens, inputRegistrationDeadline, inputEventDate, inputEventDescription, inputWaitlistLimit, inputOccupantLimit;
     private CheckBox checkboxWaitlistLimit;
     private Button btnCreateEvent;
     private DatabaseHelper dbHelper;
@@ -49,6 +49,7 @@ public class OrganizerCreateEventFragment extends Fragment {
         checkboxWaitlistLimit = view.findViewById(R.id.checkboxWaitlistLimit);
         inputWaitlistLimit = view.findViewById(R.id.inputWaitlistLimit);
         btnCreateEvent = view.findViewById(R.id.btnCreateEvent);
+        inputOccupantLimit = view.findViewById(R.id.inputOccupantLimit);
 
         // Initialize DatabaseHelper
         dbHelper = new DatabaseHelper(requireContext());
@@ -74,6 +75,8 @@ public class OrganizerCreateEventFragment extends Fragment {
         String eventDescription = inputEventDescription.getText().toString().trim();
         boolean assignWaitlistLimit = checkboxWaitlistLimit.isChecked();
         int waitlistLimit = 0;
+        String occupantLimitText = inputOccupantLimit.getText().toString().trim();
+        int occupantLimit = 100;
 
         boolean isValid = true;
 
@@ -113,6 +116,15 @@ public class OrganizerCreateEventFragment extends Fragment {
                     Toast.makeText(getContext(), "Invalid waitlist limit", Toast.LENGTH_SHORT).show();
                     return;
                 }
+            }
+        }
+
+        if (!TextUtils.isEmpty(occupantLimitText)) {
+            try {
+                occupantLimit = Integer.parseInt(occupantLimitText);
+            } catch (NumberFormatException e) {
+                Toast.makeText(getContext(), "Invalid occupant limit", Toast.LENGTH_SHORT).show();
+                return;
             }
         }
 
@@ -162,6 +174,7 @@ public class OrganizerCreateEventFragment extends Fragment {
         event.setDescription(eventDescription);
         event.setWaitlistLimitFlag(assignWaitlistLimit);
         event.setWaitlistLimit(assignWaitlistLimit ? waitlistLimit : 0);
+        event.setOccupantLimit(occupantLimit);
 
         // Set organizer ID from Device ID (current user ID)
         String organizerId = dbHelper.getCurrentUserId(); // Retrieve Device ID

--- a/tigers-lottery/app/src/main/java/com/example/tigers_lottery/HostedEvents/OrganizerEditEventFragment.java
+++ b/tigers-lottery/app/src/main/java/com/example/tigers_lottery/HostedEvents/OrganizerEditEventFragment.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.example.tigers_lottery.DatabaseHelper;
@@ -26,7 +27,7 @@ import java.util.Locale;
 
 public class OrganizerEditEventFragment extends Fragment {
 
-    private EditText inputEventName, inputEventLocation, inputRegistrationOpens, inputRegistrationDeadline, inputEventDate, inputEventDescription, inputWaitlistLimit;
+    private EditText inputEventName, inputEventLocation, inputRegistrationOpens, inputRegistrationDeadline, inputEventDate, inputEventDescription, inputWaitlistLimit, inputOccupantLimit;
     private CheckBox checkboxWaitlistLimit;
     private Button btnSaveEvent;
     private DatabaseHelper dbHelper;
@@ -50,6 +51,18 @@ public class OrganizerEditEventFragment extends Fragment {
         checkboxWaitlistLimit = view.findViewById(R.id.checkboxWaitlistLimit);
         inputWaitlistLimit = view.findViewById(R.id.inputWaitlistLimit);
         btnSaveEvent = view.findViewById(R.id.btnCreateEvent);
+        inputOccupantLimit = view.findViewById(R.id.inputOccupantLimit);
+
+        // Hide occupant limit whilst editing
+        TextView labelOccupantLimit = view.findViewById(R.id.LabelOccupantLimit);
+        labelOccupantLimit.setVisibility(View.GONE);
+        inputOccupantLimit.setVisibility(View.GONE);
+
+        // Ensure waitlist fields are hidden by default
+        TextView assignWaitlistLabel = view.findViewById(R.id.assignWaitlistLabel);
+        checkboxWaitlistLimit.setVisibility(View.GONE);
+        inputWaitlistLimit.setVisibility(View.GONE);
+        assignWaitlistLabel.setVisibility(View.GONE);
 
         // Set button text to "Save"
         btnSaveEvent.setText("Save");
@@ -77,9 +90,13 @@ public class OrganizerEditEventFragment extends Fragment {
         inputRegistrationDeadline.setText(formatTimestamp(event.getWaitlistDeadline()));
         inputEventDate.setText(formatTimestamp(event.getEventDate()));
         inputEventDescription.setText(event.getDescription());
-        checkboxWaitlistLimit.setChecked(event.isWaitlistLimitFlag());
-        inputWaitlistLimit.setText(String.valueOf(event.getWaitlistLimit()));
-        inputWaitlistLimit.setVisibility(event.isWaitlistLimitFlag() ? View.VISIBLE : View.GONE);
+
+        // Disable checkbox to ensure it doesn’t re-enable the waitlist limit field
+        checkboxWaitlistLimit.setChecked(false);
+        checkboxWaitlistLimit.setEnabled(false);
+
+        // Hide the waitlist limit input field regardless of any external listener
+        inputWaitlistLimit.setVisibility(View.GONE);
     }
 
     private void saveEvent() {

--- a/tigers-lottery/app/src/main/java/com/example/tigers_lottery/models/Event.java
+++ b/tigers-lottery/app/src/main/java/com/example/tigers_lottery/models/Event.java
@@ -59,6 +59,12 @@ public class Event implements Serializable {
     @PropertyName("declined_entrants")
     private List<String> declinedEntrants = new ArrayList<>();
 
+    @PropertyName("occupant_limit")
+    private int occupantLimit = 0;
+
+    @PropertyName("is_lottery_ran")
+    private boolean isLotteryRan = false;
+
     // No-argument constructor
     public Event() {}
 
@@ -158,6 +164,19 @@ public class Event implements Serializable {
 
     @PropertyName("declined_entrants")
     public void setDeclinedEntrants(List<String> declinedEntrants) { this.declinedEntrants = declinedEntrants; }
+
+    @PropertyName("occupant_limit")
+    public int getOccupantLimit() { return occupantLimit; }
+
+    @PropertyName("occupant_limit")
+    public void setOccupantLimit(int occupantLimit) { this.occupantLimit = occupantLimit; }
+
+    // Getter and Setter for is_lottery_ran
+    @PropertyName("is_lottery_ran")
+    public boolean isLotteryRan() { return isLotteryRan; }
+
+    @PropertyName("is_lottery_ran")
+    public void setLotteryRan(boolean lotteryRan) { isLotteryRan = lotteryRan; }
 
     // Helper methods to format Timestamps
     public String getFormattedEventDate() {

--- a/tigers-lottery/app/src/main/res/layout/organizer_createevent_fragment.xml
+++ b/tigers-lottery/app/src/main/res/layout/organizer_createevent_fragment.xml
@@ -115,6 +115,19 @@
             android:inputType="textMultiLine"
             android:layout_marginBottom="12dp" />
 
+        <!-- Occupant Limit Label and Input -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Occupant Limit" />
+        <EditText
+            android:id="@+id/inputOccupantLimit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Enter occupant limit"
+            android:inputType="number"
+            android:layout_marginBottom="16dp" />
+
         <!-- Checkbox for Waitlist Limit -->
         <LinearLayout
             android:layout_width="wrap_content"

--- a/tigers-lottery/app/src/main/res/layout/organizer_createevent_fragment.xml
+++ b/tigers-lottery/app/src/main/res/layout/organizer_createevent_fragment.xml
@@ -119,7 +119,8 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Occupant Limit" />
+            android:text="Occupant Limit"
+            android:id="@+id/LabelOccupantLimit" />
         <EditText
             android:id="@+id/inputOccupantLimit"
             android:layout_width="match_parent"
@@ -144,6 +145,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:id="@+id/assignWaitlistLabel"
                 android:text="Assign Waitlist Limit?"
                 android:paddingStart="8dp"
                 android:textSize="16sp" />

--- a/tigers-lottery/app/src/main/res/layout/organizer_eventdetails_fragment.xml
+++ b/tigers-lottery/app/src/main/res/layout/organizer_eventdetails_fragment.xml
@@ -86,7 +86,14 @@
             android:textSize="16sp"
             android:layout_marginBottom="16dp" />
 
-        <!-- Buttons to View Entrant Lists -->
+        <!-- Buttons to View Entrant Lists as well as lottery button-->
+        <Button
+            android:id="@+id/runLotteryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Run Lottery"
+            android:layout_marginBottom="16dp" />
+
         <Button
             android:id="@+id/viewRegisteredEntrants"
             android:layout_width="match_parent"


### PR DESCRIPTION
Added a field for Occupant Limit to specify the maximum number of entrants allowed to register for the event.
Added a boolean field to track if the "Run Lottery" button has been used.
Registration and Waitlist:

**Initial expected behaviour**
- Entrants can register for an event and will be initially added to a waitlisted entrants list.
- The waitlist limit (if set) will limit the number of people on the waitlist but will not affect the actual event capacity (Occupant Limit).

**Occupant Limit and Waitlist Handling:**
- During event creation, organizers can set an Occupant Limit which restricts the number of entrants who can be registered for the event.
- Organizers should see a "Run Lottery" button after the registration deadline to allocate spots based on the Occupant Limit.
Running the Lottery:

**When the organizer clicks "Run Lottery":**
- Randomly select Occupant Limit number of entrants from the waitlisted entrants list to be invited, moving them to the invited entrants list.
- Keep the remaining entrants on the waitlisted entrants list.
- The "Run Lottery" button should be greyed out after one use to prevent multiple lottery runs.
- The system should automatically re-run the lottery if someone declines the invite, randomly filling the vacancy from the waitlisted entrants.

**Post-Lottery Behavior:**
- If an entrant accepts an invite, they move from invited entrants to the registered entrants list.
- If an entrant declines an invite, they move from invited entrants to the declined entrants list.
- For each declined invite, the system automatically picks a replacement from the waitlisted entrants (if available) without organizer intervention.

**Button Visibility and Usage:**
- The "Run Lottery" button should only be clickable after the registration deadline.
- Once the lottery is run, the button should remain permanently disabled.
- On edit event screen, the waitlist and occupant limit are also removed.