### PR TITLE
PR to let organizer clear entrants from the waitlist, invited, and declined lists

### DIFF
--- a/tigers-lottery/app/src/main/java/com/example/tigers_lottery/DatabaseHelper.java
+++ b/tigers-lottery/app/src/main/java/com/example/tigers_lottery/DatabaseHelper.java
@@ -15,6 +15,7 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestore;
@@ -807,6 +808,34 @@ public class DatabaseHelper {
                 });
             }
         }).addOnFailureListener(e -> Log.e("DatabaseHelper", "Error fetching event document", e));
+    }
+
+
+    /**
+     * Clears the waitlisted, invited, and declined entrants lists for a given event.
+     *
+     * @param eventId   The ID of the event whose lists need to be cleared.
+     * @param callback  The EventsCallback to handle success or failure.
+     */
+    public void clearEventLists(int eventId, EventsCallback callback) {
+        // Reference to the event document in Firestore
+        DocumentReference eventRef = eventsRef.document(String.valueOf(eventId));
+
+        // Create an empty list to clear the lists in Firestore
+        List<String> emptyList = new ArrayList<>();
+
+        // Update the Firestore document with empty lists for the specified fields
+        eventRef.update("waitlisted_entrants", emptyList,
+                        "invited_entrants", emptyList,
+                        "declined_entrants", emptyList)
+                .addOnSuccessListener(aVoid -> {
+                    Log.d(TAG, "Successfully cleared event lists for event ID: " + eventId);
+                    callback.onEventsFetched(null);  // Trigger callback on success
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Error clearing event lists for event ID: " + eventId, e);
+                    callback.onError(e);  // Trigger error callback
+                });
     }
 
 

--- a/tigers-lottery/app/src/main/res/layout/organizer_eventdetails_fragment.xml
+++ b/tigers-lottery/app/src/main/res/layout/organizer_eventdetails_fragment.xml
@@ -93,7 +93,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Run Lottery"
-            android:layout_marginBottom="16dp" />
+            android:layout_marginBottom="8dp" />
+
+        <Button
+            android:id="@+id/clearListsButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Clear Lists"
+            android:layout_marginBottom="8dp" />
 
         <Button
             android:id="@+id/viewRegisteredEntrants"


### PR DESCRIPTION
### Changes Made
**OrganizerEventDetailsFragment:**
 Added a Clear Lists button and setupClearListsButton() method to enable organizers to clear participant lists after the event date.
**DatabaseHelper:**
Added clearEventLists() to clear lists in the event document and remove the event ID from each affected user’s joined_events list.
Created a removeEventFromJoinedEvents() helper method to update each user’s joined_events and handle any type mismatches gracefully.


### Testing
**UI Testing:**
Verified the Clear Lists button appears and is functional only after the event’s start date.
Confirmed that clicking Clear Lists successfully clears the lists and updates the Firestore database.

**Database Validation:**
Checked the event document to ensure lists are emptied as expected.
Confirmed in the user documents that the event ID is removed from joined_events for all cleared participants.

